### PR TITLE
Update masks-form-fields.php

### DIFF
--- a/trunk/masks-form-fields.php
+++ b/trunk/masks-form-fields.php
@@ -78,7 +78,7 @@ function mff_enqueue_scripts() {
 
 	$_mff = ['loader' => true];
 
-	wp_localize_script( 'masks-form-fields', '_mff', $_mff );
+	wp_add_inline_script( 'masks-form-fields', 'var _mff='.json_encode($_mff), 'before' );
 
 	do_action( 'mff_enqueue_scripts' );
 }


### PR DESCRIPTION
swap wp_localize_script for wp_add_inline_script

Enable developers to add any attribute, like nonce, to the script tag by using script_loader_tag hook